### PR TITLE
NextJS Runtime middleware example

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,14 +10,6 @@ const config = {
     reactCompiler: true,
   },
   output: "standalone",
-  async rewrites() {
-    return [
-      {
-        source: "/api/:path*",
-        destination: `http://127.0.0.1:8888/v1/:path*`, // Proxy to Backend apiBaseURL,
-      },
-    ];
-  },
 };
 
 export default config;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+// Default to localhost:8888 if env var is not set
+const API_BASE_URL = process.env.GODOXY_API_ADDR || 'http://127.0.0.1:8888'
+
+export function middleware(request: NextRequest) {
+  // Get the pathname of the request (e.g. /api/users)
+  const pathname = request.nextUrl.pathname
+
+  console.log(`[Middleware] Incoming request to: ${pathname}`)
+  console.log(`[Middleware] API_BASE_URL: ${API_BASE_URL}`)
+
+  // Check if it's an API route
+  if (pathname.startsWith('/api/')) {
+    // Remove the /api prefix and add v1 instead
+    const apiPath = pathname.replace(/^\/api/, '/v1')
+    // Create the URL for the proxied request
+    const url = new URL(apiPath, API_BASE_URL)
+    
+    // Preserve query parameters
+    url.search = request.nextUrl.search
+    
+    console.log(`[Middleware] Rewriting to: ${url.toString()}`)
+    
+    // Return rewritten URL response
+    return NextResponse.rewrite(url)
+  }
+
+  console.log('[Middleware] Not an API route, passing through')
+}
+
+// Configure matcher for paths that trigger this middleware
+export const config = {
+  matcher: '/api/:path*',
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,9 +8,6 @@ export function middleware(request: NextRequest) {
   // Get the pathname of the request (e.g. /api/users)
   const pathname = request.nextUrl.pathname
 
-  console.log(`[Middleware] Incoming request to: ${pathname}`)
-  console.log(`[Middleware] API_BASE_URL: ${API_BASE_URL}`)
-
   // Check if it's an API route
   if (pathname.startsWith('/api/')) {
     // Remove the /api prefix and add v1 instead
@@ -20,14 +17,10 @@ export function middleware(request: NextRequest) {
     
     // Preserve query parameters
     url.search = request.nextUrl.search
-    
-    console.log(`[Middleware] Rewriting to: ${url.toString()}`)
-    
+        
     // Return rewritten URL response
     return NextResponse.rewrite(url)
   }
-
-  console.log('[Middleware] Not an API route, passing through')
 }
 
 // Configure matcher for paths that trigger this middleware


### PR DESCRIPTION
I hope this helps with the `GODOXY_API_ADDR` issue. 

The issue is that the configuration in `next.config.js` rewrites at compile time and not runtime. In order to be able to dynamically change the address, you would need to use middleware.

This PR is an example of using the middleware to proxy the request to the api. I have deliberately left the debug logging in because I'm still having a connection refused issue. But I believe it may be an issue with my own personal setup. I'll continue to debug on my side, but I believe you may have a more comprehensive knowledge of the api portion. 😄 

Let me know if you have any questions or if I can help further!